### PR TITLE
Handle spaces in policy JSON filenames.

### DIFF
--- a/xbundle/__init__.py
+++ b/xbundle/__init__.py
@@ -250,7 +250,7 @@ class XBundle(object):
             policies = etree.Element('policies')
             policies.set('semester',os.path.basename(pdir))
             for fn in glob.glob(join(pdir, '*.json')):
-                x = etree.SubElement(policies,os.path.basename(fn).replace('_','').replace('.json',''))
+                x = etree.SubElement(policies,os.path.basename(fn).replace('_','').replace('.json','').replace(" ", "_"))
                 x.text = open(fn).read()
             self.add_policies(policies)
         


### PR DESCRIPTION
To address #13.

Another `replace()` was just tacked onto the existing line. No pylint cleanup of line length was done in this commit, for clarity.