### PR TITLE
Fix issues with spaces in JSON filenames.

### DIFF
--- a/xbundle/__init__.py
+++ b/xbundle/__init__.py
@@ -21,7 +21,7 @@ import re
 import string
 import glob
 import subprocess
-from os.path import join, exists
+from os.path import join, exists, basename
 
 from lxml import etree
 from lxml.html.soupparser import fromstring as fsbs
@@ -249,7 +249,10 @@ class XBundle(object):
             # print "pdir=",pdir
             policies = etree.Element('policies')
             policies.set('semester',os.path.basename(pdir))
+            policy_files = set(["policy.json", "grading_policy.json"])
             for fn in glob.glob(join(pdir, '*.json')):
+                if basename(fn) not in policy_files:
+                    continue
                 x = etree.SubElement(policies,os.path.basename(fn).replace('_','').replace('.json',''))
                 x.text = open(fn).read().decode('utf-8')
             self.add_policies(policies)


### PR DESCRIPTION
Nobody cares about the files unless they're one of these:

    policy.json
    grading_policy.json

Everything else is random stuff added by the author, which we
can safely ignore.

Fixes #13.