### PR TITLE
Release 0.2.1

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,10 @@
 xbundle Release Notes
 =====================
 
+0.2.1 Release
+
+- Added preserve_url_name flag to keep url_name in imported XML.
+
 0.2.0 Release
 
 - standardized setup.py metadata

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as readme_file:
 
 setup(
     name='xbundle',
-    version="0.2.0",
+    version="0.2.1",
     packages=['xbundle'],
     scripts=['bin/xbundle_convert'],
     author='MIT ODL Engineering',


### PR DESCRIPTION
This release necessary to get LORE to upgrade xbundle correctly. Pinning the git hash doesn't seem to work for our heroku deploy