### PR TITLE
Allow import of verticals from files

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,10 @@
 xbundle Release Notes
 =====================
 
+0.3.1 Release
+
+- Fixed issue in import which prevented import of nested content in some cases.
+
 0.3.0 Release
 
 - Added preserve_url_name flag to keep url_name in imported XML.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as readme_file:
 
 setup(
     name='xbundle',
-    version="0.3.0",
+    version="0.3.1",
     packages=['xbundle'],
     scripts=['bin/xbundle_convert'],
     author='MIT ODL Engineering',


### PR DESCRIPTION
Removing ```sequential``` from DESCRIPTOR_TAGS avoids skipping importing sequentials' child verticals' content files.