### PR TITLE
Support for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python: 2.7
+sudo: false
+env:
+  - TOX_ENV=py27
+  - TOX_ENV=py34
+install:
+  - pip install tox
+script:
+  - tox -e $TOX_ENV

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 xbundle
 =======
 
+.. image:: https://travis-ci.org/mitodl/xbundle.svg?branch=travis
+    :target: https://travis-ci.org/mitodl/xbundle
+
+.. image:: https://coveralls.io/repos/mitodl/xbundle/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/mitodl/xbundle?branch=master             
+
 ``xbundle`` converts back and forth between OLX and "xbundle" style XML
 formats. The xbundle format is a single XML file.
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,4 +3,4 @@ pytest<2.8
 pytest-pep8
 pytest-pylint
 pytest-cov
-
+coveralls

--- a/tests/util.py
+++ b/tests/util.py
@@ -14,8 +14,14 @@ def clean_xml(xml_str):
     Remove whitespace from XML.
     """
     parser = etree.XMLParser(remove_blank_text=True)
-    return etree.tostring(
+    xml_string = etree.tostring(
         etree.XML(xml_str, parser=parser))
+    try:
+        xml_string = xml_string.decode('utf-8')
+    except AttributeError:
+        pass
+
+    return xml_string
 
 
 def file_from_string(xml_str):

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,14 @@ deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test_requirements.txt
 commands = py.test {posargs}
+whitelist_externals=coveralls
 passenv = *
 setenv =
     PYTHONPATH = {toxinidir}
+
+# used to report coverage only on py27 as coveralls can't take
+# multiple results.
+[testenv:py27]
+commands =
+    py.test {posargs}
+    - coveralls


### PR DESCRIPTION
I've normalized the whitespace in the tests because the XML serialization on Travis was different than locally. It would do things like:

```
<foo></foo>
```

And the expected format was

```
<foo>
</foo>
```

Both of which are completely valid XML.
